### PR TITLE
Support for particles color & others changes

### DIFF
--- a/src/main/java/com/rojel/wesv/Configuration.java
+++ b/src/main/java/com/rojel/wesv/Configuration.java
@@ -6,11 +6,17 @@ package com.rojel.wesv;
 
 import java.util.EnumMap;
 
+import org.bukkit.ChatColor;
+import org.bukkit.Material;
 import org.bukkit.configuration.file.FileConfiguration;
 import org.bukkit.entity.Player;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import com.darkblade12.particleeffect.ParticleEffect;
+import com.darkblade12.particleeffect.ParticleEffect.BlockData;
+import com.darkblade12.particleeffect.ParticleEffect.ItemData;
+import com.darkblade12.particleeffect.ParticleEffect.OrdinaryColor;
+import com.darkblade12.particleeffect.ParticleEffect.ParticleProperty;
 
 /**
  * YAML plugin configuration retrieval and manipulation class.
@@ -38,86 +44,92 @@ public class Configuration {
 	/**
 	 * ENUM of valid configuration values.
 	 */
-	private enum CONFIG_VALUES {
+	private enum ConfigValue {
 		/**
 		 * Size of a space left between 2 points.
 		 */
-		GAPBETWEENPOINTS("gapBetweenPoints"),
+		GAPBETWEENPOINTS("gapBetweenPoints", 0.5d),
 		/**
 		 * Size of a vertical space left between 2 points.
 		 */
-		VERTICALGAP("verticalGap"),
+		VERTICALGAP("verticalGap", 1d),
 		/**
 		 * Interval in which particles should be updated for the MC client.
 		 */
-		UPDATEPARTICLESINTERVAL("updateParticlesInterval"),
+		UPDATEPARTICLESINTERVAL("updateParticlesInterval", 5),
 		/**
 		 * Interval (ms) in which the selection should be updated for the MC
 		 * client.
 		 */
-		UPDATESELECTIONINTERVAL("updateSelectionInterval"),
+		UPDATESELECTIONINTERVAL("updateSelectionInterval", 20),
 		/**
 		 * Whether or not to show cuboid lines.
 		 */
-		CUBOIDLINES("horizontalLinesForCuboid"),
+		CUBOIDLINES("horizontalLinesForCuboid", true),
 		/**
 		 * Whether or not to show polygon lines.
 		 */
-		POLYGONLINES("horizontalLinesForPolygon"),
+		POLYGONLINES("horizontalLinesForPolygon", true),
 		/**
 		 * Whether or not to show cylinder lines.
 		 */
-		CYLINDERLINES("horizontalLinesForCylinder"),
+		CYLINDERLINES("horizontalLinesForCylinder", true),
 		/**
 		 * Whether or not to show ellipsoid lines.
 		 */
-		ELLIPSOIDLINES("horizontalLinesForEllipsoid"),
+		ELLIPSOIDLINES("horizontalLinesForEllipsoid", true),
 		/**
 		 * Whether or not to check for the WorldEdit tool in hand.
 		 */
-		CHECKFORAXE("checkForAxe"),
+		CHECKFORAXE("checkForAxe", true),
 		/**
 		 * Maximum distance to see selection particles from.
 		 */
-		PARTICLEDISTANCE("particleDistance"),
+		PARTICLEDISTANCE("particleDistance", 32),
 		/**
 		 * Maximum size of the visualized selection itself.
 		 */
-		MAXSIZE("maxSize"),
+		MAXSIZE("maxSize", 10000),
 		/**
 		 * Language translation string from config.
 		 */
-		LANGVISUALIZERENABLED("lang.visualizerEnabled"),
+		LANGVISUALIZERENABLED("lang.visualizerEnabled", "Your visualizer has been enabled."),
 		/**
 		 * Language translation string from config.
 		 */
-		LANGVISUALIZERDISABLED("lang.visualizerDisabled"),
+		LANGVISUALIZERDISABLED("lang.visualizerDisabled", "Your visualizer has been disabled."),
 		/**
 		 * Language translation string from config.
 		 */
-		LANGPLAYERSONLY("lang.playersOnly"),
+		LANGPLAYERSONLY("lang.playersOnly", "Only a player can toggle his visualizer."),
 		/**
 		 * Language translation string from config.
 		 */
-		LANGSELECTIONSIZEOF("lang.selectionSizeOf"),
+		LANGSELECTIONSIZEOF("lang.selectionSizeOf", "The visualizer only works with selections up to a size of "),
 		/**
 		 * Language translation string from config.
 		 */
-		LANGBLOCKS("lang.blocks"),
+		LANGBLOCKS("lang.blocks", "blocks"),
 		/**
 		 * Language translation string from config.
 		 */
-		LANGCONFIGRELOADED("lang.configReloaded"),
+		LANGCONFIGRELOADED("lang.configReloaded", "Configuration for visualizer was reloaded from the disk."),
 
 		/**
 		 * Hide particles after a confgured amount of time
 		 */
-		FADE_DELAY("particleFadeDelay");
+		FADE_DELAY("particleFadeDelay", 0),
+
+		/**
+		 * Additional data for some particles (can be a color or a material)
+		 */
+		PARTICLE_DATA("particleData", "255,255,255");
 
 		/**
 		 * The string value of an ENUM.
 		 */
 		private final String configValue;
+		private final Object defaultValue;
 
 		/**
 		 * Constructor for String ENUMs.
@@ -125,8 +137,9 @@ public class Configuration {
 		 * @param value
 		 *            String value for the ENUM.
 		 */
-		CONFIG_VALUES(final String value) {
+		ConfigValue(final String value, final Object defaultValue) {
 			this.configValue = value;
+			this.defaultValue = defaultValue;
 		}
 
 		/*
@@ -138,75 +151,13 @@ public class Configuration {
 		public String toString() {
 			return this.configValue;
 		}
+
+		public Object getDefaultValue() {
+			return defaultValue;
+		}
 	}
 
-	/**
-	 * Configuration HashMap containing all configuration options and their
-	 * values. This configuration comes from config.yml file.
-	 */
-	private final EnumMap<CONFIG_VALUES, Object> configItems = new EnumMap<CONFIG_VALUES, Object>(CONFIG_VALUES.class) {
-
-		private static final long serialVersionUID = 634292893169729562L;
-
-		{
-
-			// Size of a space left between 2 points.
-			this.put(CONFIG_VALUES.GAPBETWEENPOINTS, 0.5d);
-
-			// Size of a vertical space left between 2 points.
-			this.put(CONFIG_VALUES.VERTICALGAP, 1d);
-
-			// Interval (ms) in which particles should be updated for the MC
-			// client.
-			this.put(CONFIG_VALUES.UPDATEPARTICLESINTERVAL, 5);
-
-			// Interval (ms) in which the selection should be updated for the MC
-			// client.
-			this.put(CONFIG_VALUES.UPDATESELECTIONINTERVAL, 20);
-
-			// Whether or not to show cuboid lines.
-			this.put(CONFIG_VALUES.CUBOIDLINES, true);
-
-			// Whether or not to show polygon lines.
-			this.put(CONFIG_VALUES.POLYGONLINES, true);
-
-			// Whether or not to show cylinder lines.
-			this.put(CONFIG_VALUES.CYLINDERLINES, true);
-
-			// Whether or not to show ellipsoid lines.
-			this.put(CONFIG_VALUES.ELLIPSOIDLINES, true);
-
-			// Whether or not to check for the WorldEdit tool in hand.
-			this.put(CONFIG_VALUES.CHECKFORAXE, true);
-
-			// Maximum distance to see selection particles from.
-			this.put(CONFIG_VALUES.PARTICLEDISTANCE, 32);
-
-			// Maximum size of the visualized selection itself.
-			this.put(CONFIG_VALUES.MAXSIZE, 10000);
-
-			// Language translation string from config.
-			this.put(CONFIG_VALUES.LANGVISUALIZERENABLED, "Your visualizer has been enabled.");
-
-			// Language translation string from config.
-			this.put(CONFIG_VALUES.LANGVISUALIZERDISABLED, "Your visualizer has been disabled.");
-
-			// Language translation string from config.
-			this.put(CONFIG_VALUES.LANGPLAYERSONLY, "Only a player can toggle his visualizer.");
-
-			// Language translation string from config.
-			this.put(CONFIG_VALUES.LANGSELECTIONSIZEOF, "The visualizer only works with selections up to a size of ");
-
-			// Language translation string from config.
-			this.put(CONFIG_VALUES.LANGBLOCKS, "blocks");
-
-			// Language translation string from config.
-			this.put(CONFIG_VALUES.LANGCONFIGRELOADED, "Configuration for visualizer was reloaded from the disk.");
-			
-			this.put(CONFIG_VALUES.FADE_DELAY, 0);
-
-		}
-	};
+	private final EnumMap<ConfigValue, Object> configItems = new EnumMap<>(ConfigValue.class);
 
 	/**
 	 * Constructor, takes the WESV plugin instance as a parameter.
@@ -216,6 +167,10 @@ public class Configuration {
 	 */
 	public Configuration(final JavaPlugin plugin) {
 		this.plugin = plugin;
+
+		for (final ConfigValue values : ConfigValue.values()) {
+			configItems.put(values, values.getDefaultValue());
+		}
 	}
 
 	/**
@@ -224,7 +179,13 @@ public class Configuration {
 	public void load() {
 		this.plugin.saveDefaultConfig();
 		this.config = this.plugin.getConfig();
+
+		for (final ConfigValue values : ConfigValue.values()) {
+			this.config.addDefault(values.toString(), values.getDefaultValue());
+		}
+
 		this.config.options().copyDefaults(true);
+		this.plugin.saveConfig();
 		this.reloadConfig();
 	}
 
@@ -237,54 +198,53 @@ public class Configuration {
 
 		this.particle = this.getParticleEffect(this.config.getString("particleEffect"));
 
-		this.configItems.put(CONFIG_VALUES.GAPBETWEENPOINTS,
-				this.config.getDouble(CONFIG_VALUES.GAPBETWEENPOINTS.toString()));
+		this.configItems.put(ConfigValue.GAPBETWEENPOINTS,
+				this.config.getDouble(ConfigValue.GAPBETWEENPOINTS.toString()));
 
-		this.configItems.put(CONFIG_VALUES.VERTICALGAP, this.config.getDouble(CONFIG_VALUES.VERTICALGAP.toString()));
+		this.configItems.put(ConfigValue.VERTICALGAP, this.config.getDouble(ConfigValue.VERTICALGAP.toString()));
 
-		this.configItems.put(CONFIG_VALUES.UPDATEPARTICLESINTERVAL,
-				this.config.getInt(CONFIG_VALUES.UPDATEPARTICLESINTERVAL.toString()));
+		this.configItems.put(ConfigValue.UPDATEPARTICLESINTERVAL,
+				this.config.getInt(ConfigValue.UPDATEPARTICLESINTERVAL.toString()));
 
-		this.configItems.put(CONFIG_VALUES.UPDATESELECTIONINTERVAL,
-				this.config.getInt(CONFIG_VALUES.UPDATESELECTIONINTERVAL.toString()));
+		this.configItems.put(ConfigValue.UPDATESELECTIONINTERVAL,
+				this.config.getInt(ConfigValue.UPDATESELECTIONINTERVAL.toString()));
 
-		this.configItems.put(CONFIG_VALUES.CUBOIDLINES, this.config.getBoolean(CONFIG_VALUES.CUBOIDLINES.toString()));
+		this.configItems.put(ConfigValue.CUBOIDLINES, this.config.getBoolean(ConfigValue.CUBOIDLINES.toString()));
 
-		this.configItems.put(CONFIG_VALUES.POLYGONLINES, this.config.getBoolean(CONFIG_VALUES.POLYGONLINES.toString()));
+		this.configItems.put(ConfigValue.POLYGONLINES, this.config.getBoolean(ConfigValue.POLYGONLINES.toString()));
 
-		this.configItems.put(CONFIG_VALUES.CYLINDERLINES,
-				this.config.getBoolean(CONFIG_VALUES.CYLINDERLINES.toString()));
+		this.configItems.put(ConfigValue.CYLINDERLINES, this.config.getBoolean(ConfigValue.CYLINDERLINES.toString()));
 
-		this.configItems.put(CONFIG_VALUES.ELLIPSOIDLINES,
-				this.config.getBoolean(CONFIG_VALUES.ELLIPSOIDLINES.toString()));
+		this.configItems.put(ConfigValue.ELLIPSOIDLINES, this.config.getBoolean(ConfigValue.ELLIPSOIDLINES.toString()));
 
-		this.configItems.put(CONFIG_VALUES.CHECKFORAXE, this.config.getBoolean(CONFIG_VALUES.CHECKFORAXE.toString()));
+		this.configItems.put(ConfigValue.CHECKFORAXE, this.config.getBoolean(ConfigValue.CHECKFORAXE.toString()));
 
-		this.configItems.put(CONFIG_VALUES.PARTICLEDISTANCE,
-				this.config.getInt(CONFIG_VALUES.PARTICLEDISTANCE.toString()));
+		this.configItems.put(ConfigValue.PARTICLEDISTANCE, this.config.getInt(ConfigValue.PARTICLEDISTANCE.toString()));
 
-		this.configItems.put(CONFIG_VALUES.MAXSIZE, this.config.getInt(CONFIG_VALUES.MAXSIZE.toString()));
+		this.configItems.put(ConfigValue.MAXSIZE, this.config.getInt(ConfigValue.MAXSIZE.toString()));
 
 		// language config
-		this.configItems.put(CONFIG_VALUES.LANGVISUALIZERENABLED,
-				this.config.getString(CONFIG_VALUES.LANGVISUALIZERENABLED.toString()));
+		this.configItems.put(ConfigValue.LANGVISUALIZERENABLED,
+				this.config.getString(ConfigValue.LANGVISUALIZERENABLED.toString()));
 
-		this.configItems.put(CONFIG_VALUES.LANGVISUALIZERDISABLED,
-				this.config.getString(CONFIG_VALUES.LANGVISUALIZERDISABLED.toString()));
+		this.configItems.put(ConfigValue.LANGVISUALIZERDISABLED,
+				this.config.getString(ConfigValue.LANGVISUALIZERDISABLED.toString()));
 
-		this.configItems.put(CONFIG_VALUES.LANGPLAYERSONLY,
-				this.config.getString(CONFIG_VALUES.LANGPLAYERSONLY.toString()));
+		this.configItems.put(ConfigValue.LANGPLAYERSONLY,
+				this.config.getString(ConfigValue.LANGPLAYERSONLY.toString()));
 
-		this.configItems.put(CONFIG_VALUES.LANGSELECTIONSIZEOF,
-				this.config.getString(CONFIG_VALUES.LANGSELECTIONSIZEOF.toString()));
+		this.configItems.put(ConfigValue.LANGSELECTIONSIZEOF,
+				this.config.getString(ConfigValue.LANGSELECTIONSIZEOF.toString()));
 
-		this.configItems.put(CONFIG_VALUES.LANGBLOCKS, this.config.getString(CONFIG_VALUES.LANGBLOCKS.toString()));
+		this.configItems.put(ConfigValue.LANGBLOCKS, this.config.getString(ConfigValue.LANGBLOCKS.toString()));
 
-		this.configItems.put(CONFIG_VALUES.LANGCONFIGRELOADED,
-				this.config.getString(CONFIG_VALUES.LANGCONFIGRELOADED.toString()));
-		
-		this.configItems.put(CONFIG_VALUES.FADE_DELAY,
-				this.config.getInt(CONFIG_VALUES.FADE_DELAY.toString()));
+		this.configItems.put(ConfigValue.LANGCONFIGRELOADED,
+				this.config.getString(ConfigValue.LANGCONFIGRELOADED.toString()));
+
+		this.configItems.put(ConfigValue.FADE_DELAY, this.config.getInt(ConfigValue.FADE_DELAY.toString()));
+
+		this.configItems.put(ConfigValue.PARTICLE_DATA,
+				getParticleData(this.config.getString(ConfigValue.PARTICLE_DATA.toString())));
 	}
 
 	/**
@@ -296,11 +256,44 @@ public class Configuration {
 	 */
 	public ParticleEffect getParticleEffect(final String name) {
 		final ParticleEffect effect = ParticleEffect.fromName(name);
-		if (effect != null) {
+		if (effect != null && effect.isSupported() && !effect.hasProperty(ParticleProperty.REQUIRES_WATER)) {
 			return effect;
 		}
 		this.plugin.getLogger().warning("The particle effect set in the configuration file is invalid.");
 		return ParticleEffect.REDSTONE;
+	}
+
+	public Object getParticleData(final String name) {
+		if (this.particle.hasProperty(ParticleProperty.COLORABLE) && !name.isEmpty()) {
+			final String[] split = name.split(",");
+			if (split.length == 3) {
+				try {
+					final int r = Integer.parseInt(split[0]);
+					final int g = Integer.parseInt(split[1]);
+					final int b = Integer.parseInt(split[2]);
+
+					return new OrdinaryColor(r, g, b);
+				} catch (Exception e) {
+					this.plugin.getLogger().warning("'" + name + "' is not a valid color: " + e.getMessage());
+				}
+			}
+		} else if (this.particle.hasProperty(ParticleProperty.REQUIRES_DATA)) {
+			Material material = Material.matchMaterial(name);
+			if (material != null) {
+				if (this.particle == ParticleEffect.ITEM_CRACK) {
+					return new ItemData(material, (byte) 0);
+				} else {
+					return new BlockData(material, (byte) 0);
+				}
+			} else {
+				this.plugin.getLogger().warning(
+						"You need to set 'particleData' in the config to a valid material to use the particle effect '"
+								+ this.particle.getName() + "'");
+
+				this.particle = ParticleEffect.REDSTONE;
+			}
+		}
+		return null;
 	}
 
 	/**
@@ -346,7 +339,7 @@ public class Configuration {
 	 * @return Returns the "gapBetweenPoints" property value.
 	 */
 	public double getGapBetweenPoints() {
-		return (double) this.configItems.get(CONFIG_VALUES.GAPBETWEENPOINTS);
+		return (double) this.configItems.get(ConfigValue.GAPBETWEENPOINTS);
 	}
 
 	/**
@@ -355,7 +348,7 @@ public class Configuration {
 	 * @return Returns the "verticalGap" property value.
 	 */
 	public double getVerticalGap() {
-		return (double) this.configItems.get(CONFIG_VALUES.VERTICALGAP);
+		return (double) this.configItems.get(ConfigValue.VERTICALGAP);
 	}
 
 	/**
@@ -364,7 +357,7 @@ public class Configuration {
 	 * @return Returns the "updateParticlesInterval" property value.
 	 */
 	public int getUpdateParticlesInterval() {
-		return (int) this.configItems.get(CONFIG_VALUES.UPDATEPARTICLESINTERVAL);
+		return (int) this.configItems.get(ConfigValue.UPDATEPARTICLESINTERVAL);
 	}
 
 	/**
@@ -373,7 +366,7 @@ public class Configuration {
 	 * @return Returns the "updateSelectionInterval" property value.
 	 */
 	public int getUpdateSelectionInterval() {
-		return (int) this.configItems.get(CONFIG_VALUES.UPDATESELECTIONINTERVAL);
+		return (int) this.configItems.get(ConfigValue.UPDATESELECTIONINTERVAL);
 	}
 
 	/**
@@ -382,7 +375,7 @@ public class Configuration {
 	 * @return Returns the "cuboidLines" property value.
 	 */
 	public boolean isCuboidLinesEnabled() {
-		return (boolean) this.configItems.get(CONFIG_VALUES.CUBOIDLINES);
+		return (boolean) this.configItems.get(ConfigValue.CUBOIDLINES);
 	}
 
 	/**
@@ -391,7 +384,7 @@ public class Configuration {
 	 * @return Returns the "polygonLines" property value.
 	 */
 	public boolean isPolygonLinesEnabled() {
-		return (boolean) this.configItems.get(CONFIG_VALUES.POLYGONLINES);
+		return (boolean) this.configItems.get(ConfigValue.POLYGONLINES);
 	}
 
 	/**
@@ -400,7 +393,7 @@ public class Configuration {
 	 * @return Returns the "cylinderLines" property value.
 	 */
 	public boolean isCylinderLinesEnabled() {
-		return (boolean) this.configItems.get(CONFIG_VALUES.CYLINDERLINES);
+		return (boolean) this.configItems.get(ConfigValue.CYLINDERLINES);
 	}
 
 	/**
@@ -409,7 +402,7 @@ public class Configuration {
 	 * @return Returns the "ellipsoidLines" property value.
 	 */
 	public boolean isEllipsoidLinesEnabled() {
-		return (boolean) this.configItems.get(CONFIG_VALUES.ELLIPSOIDLINES);
+		return (boolean) this.configItems.get(ConfigValue.ELLIPSOIDLINES);
 	}
 
 	/**
@@ -418,7 +411,7 @@ public class Configuration {
 	 * @return Returns the "checkForAxe" property value.
 	 */
 	public boolean isCheckForAxeEnabled() {
-		return (boolean) this.configItems.get(CONFIG_VALUES.CHECKFORAXE);
+		return (boolean) this.configItems.get(ConfigValue.CHECKFORAXE);
 	}
 
 	/**
@@ -427,7 +420,7 @@ public class Configuration {
 	 * @return Returns the "particleDistance" property value.
 	 */
 	public int getParticleDistance() {
-		return (int) this.configItems.get(CONFIG_VALUES.PARTICLEDISTANCE);
+		return (int) this.configItems.get(ConfigValue.PARTICLEDISTANCE);
 	}
 
 	/**
@@ -436,7 +429,7 @@ public class Configuration {
 	 * @return Returns the "maxSize" property value.
 	 */
 	public int getMaxSize() {
-		return (int) this.configItems.get(CONFIG_VALUES.MAXSIZE);
+		return (int) this.configItems.get(ConfigValue.MAXSIZE);
 	}
 
 	/**
@@ -445,7 +438,7 @@ public class Configuration {
 	 * @return Translation of "langVisualizerEnabled".
 	 */
 	public String getLangVisualizerEnabled() {
-		return (String) this.configItems.get(CONFIG_VALUES.LANGVISUALIZERENABLED);
+		return color((String) this.configItems.get(ConfigValue.LANGVISUALIZERENABLED));
 	}
 
 	/**
@@ -454,7 +447,7 @@ public class Configuration {
 	 * @return Translation of "visualizerDisabled".
 	 */
 	public String getLangVisualizerDisabled() {
-		return (String) this.configItems.get(CONFIG_VALUES.LANGVISUALIZERDISABLED);
+		return color((String) this.configItems.get(ConfigValue.LANGVISUALIZERDISABLED));
 	}
 
 	/**
@@ -463,7 +456,7 @@ public class Configuration {
 	 * @return Translation of "playersOnly".
 	 */
 	public String getLangPlayersOnly() {
-		return (String) this.configItems.get(CONFIG_VALUES.LANGPLAYERSONLY);
+		return color((String) this.configItems.get(ConfigValue.LANGPLAYERSONLY));
 	}
 
 	/**
@@ -472,7 +465,7 @@ public class Configuration {
 	 * @return Translation of "selectionSizeOf".
 	 */
 	public String getLangSelectionSizeOf() {
-		return (String) this.configItems.get(CONFIG_VALUES.LANGSELECTIONSIZEOF);
+		return color((String) this.configItems.get(ConfigValue.LANGSELECTIONSIZEOF));
 	}
 
 	/**
@@ -481,7 +474,7 @@ public class Configuration {
 	 * @return Translation of "langBlocks".
 	 */
 	public String getLangBlocks() {
-		return (String) this.configItems.get(CONFIG_VALUES.LANGBLOCKS);
+		return color((String) this.configItems.get(ConfigValue.LANGBLOCKS));
 	}
 
 	/**
@@ -490,11 +483,19 @@ public class Configuration {
 	 * @return Translation of "configReloaded".
 	 */
 	public String getConfigReloaded() {
-		return (String) this.configItems.get(CONFIG_VALUES.LANGCONFIGRELOADED);
+		return (String) this.configItems.get(ConfigValue.LANGCONFIGRELOADED);
 	}
-	
+
 	// TODO JavaDoc
 	public int getParticleFadeDelay() {
-		return (int) this.configItems.get(CONFIG_VALUES.FADE_DELAY);
+		return (int) this.configItems.get(ConfigValue.FADE_DELAY);
+	}
+
+	public Object getParticleData() {
+		return this.configItems.get(ConfigValue.PARTICLE_DATA);
+	}
+
+	private String color(String msg) {
+		return ChatColor.translateAlternateColorCodes('&', msg);
 	}
 }

--- a/src/main/java/com/rojel/wesv/Configuration.java
+++ b/src/main/java/com/rojel/wesv/Configuration.java
@@ -273,12 +273,12 @@ public class Configuration {
 					final int b = Integer.parseInt(split[2]);
 
 					return new OrdinaryColor(r, g, b);
-				} catch (Exception e) {
+				} catch (IllegalArgumentException e) {
 					this.plugin.getLogger().warning("'" + name + "' is not a valid color: " + e.getMessage());
 				}
 			}
 		} else if (this.particle.hasProperty(ParticleProperty.REQUIRES_DATA)) {
-			Material material = Material.matchMaterial(name);
+			final Material material = Material.matchMaterial(name);
 			if (material != null) {
 				if (this.particle == ParticleEffect.ITEM_CRACK) {
 					return new ItemData(material, (byte) 0);
@@ -495,7 +495,7 @@ public class Configuration {
 		return this.configItems.get(ConfigValue.PARTICLE_DATA);
 	}
 
-	private String color(String msg) {
-		return ChatColor.translateAlternateColorCodes('&', msg);
+	private String color(final String s) {
+		return ChatColor.translateAlternateColorCodes('&', s);
 	}
 }

--- a/src/main/java/com/rojel/wesv/CustomMetrics.java
+++ b/src/main/java/com/rojel/wesv/CustomMetrics.java
@@ -21,12 +21,12 @@ public class CustomMetrics {
     /**
      * Configuration option for disabled metrics options.
      */
-    private static final String disabledValue = "Disabled";
+    private static final String DISABLED_VALUE = "Disabled";
 
     /**
      * Configuration option for enabled metrics options.
      */
-    private static final String enabledValue = "Enabled";
+    private static final String ENABLED_VALUE = "Enabled";
 
     /**
      * The plugin for which these statistics are being collected.
@@ -109,19 +109,19 @@ public class CustomMetrics {
 
             // create graph for Horizontal lines for cuboid selections
             this.addMcstatsGraph(metrics, "Horizontal lines for cuboid selections",
-                    this.config.isCuboidLinesEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                    this.config.isCuboidLinesEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
             // create graph for Horizontal lines for polygon selections
             this.addMcstatsGraph(metrics, "Horizontal lines for polygon selections",
-                    this.config.isPolygonLinesEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                    this.config.isPolygonLinesEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
             // create graph for Horizontal lines for cylinder selections
             this.addMcstatsGraph(metrics, "Horizontal lines for cylinder selections",
-                    this.config.isCylinderLinesEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                    this.config.isCylinderLinesEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
             // create graph for Horizontal lines for ellipsoid selections
             this.addMcstatsGraph(metrics, "Horizontal lines for ellipsoid selections",
-                    this.config.isEllipsoidLinesEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                    this.config.isEllipsoidLinesEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
             // create graph for Gap between points
             this.addMcstatsGraph(metrics, "Gap between points", "" + this.config.getGapBetweenPoints() + "");
@@ -143,7 +143,7 @@ public class CustomMetrics {
 
             // create graph for Check for axe
             this.addMcstatsGraph(metrics, "Check for axe",
-                    this.config.isCheckForAxeEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                    this.config.isCheckForAxeEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
             // create graph for Particle distance
             this.addMcstatsGraph(metrics, "Particle distance", "" + this.config.getParticleDistance() + "");
@@ -171,19 +171,19 @@ public class CustomMetrics {
 
         // create graph for Horizontal lines for cuboid selections
         this.addBcstatsGraph(bmetrics, "h_lines_cuboid",
-                this.config.isCuboidLinesEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                this.config.isCuboidLinesEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
         // create graph for Horizontal lines for polygon selections
         this.addBcstatsGraph(bmetrics, "h_lines_polygon",
-                this.config.isPolygonLinesEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                this.config.isPolygonLinesEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
         // create graph for Horizontal lines for cylinder selections
         this.addBcstatsGraph(bmetrics, "h_lines_cylinder",
-                this.config.isCylinderLinesEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                this.config.isCylinderLinesEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
         // create graph for Horizontal lines for ellipsoid selections
         this.addBcstatsGraph(bmetrics, "h_lines_ellipsoid",
-                this.config.isEllipsoidLinesEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                this.config.isEllipsoidLinesEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
         // create graph for Gap between points
         this.addBcstatsGraph(bmetrics, "gap_between_points", "" + this.config.getGapBetweenPoints() + "");
@@ -202,7 +202,7 @@ public class CustomMetrics {
 
         // create graph for Check for axe
         this.addBcstatsGraph(bmetrics, "check_for_axe",
-                this.config.isCheckForAxeEnabled() ? CustomMetrics.enabledValue : CustomMetrics.disabledValue);
+                this.config.isCheckForAxeEnabled() ? CustomMetrics.ENABLED_VALUE : CustomMetrics.DISABLED_VALUE);
 
         // create graph for Particle distance
         this.addBcstatsGraph(bmetrics, "particle_distance", "" + this.config.getParticleDistance() + "");

--- a/src/main/java/com/rojel/wesv/ParticleTask.java
+++ b/src/main/java/com/rojel/wesv/ParticleTask.java
@@ -10,13 +10,17 @@ import org.bukkit.Location;
 import org.bukkit.entity.Player;
 import org.bukkit.scheduler.BukkitRunnable;
 
+import com.darkblade12.particleeffect.ParticleEffect;
+import com.darkblade12.particleeffect.ParticleEffect.ParticleColor;
+import com.darkblade12.particleeffect.ParticleEffect.ParticleData;
+
 public class ParticleTask extends BukkitRunnable {
 
 	private final WorldEditSelectionVisualizer plugin;
 
 	public ParticleTask(final WorldEditSelectionVisualizer plugin) {
 		super();
-		
+
 		this.plugin = plugin;
 
 		runTaskTimer(this.plugin, 1, plugin.getCustomConfig().getUpdateParticlesInterval());
@@ -33,7 +37,16 @@ public class ParticleTask extends BukkitRunnable {
 					continue;
 				}
 
-				plugin.getCustomConfig().getParticle().display(0.0f, 0.0f, 0.0f, 0.0f, 1, loc, player);
+				final ParticleEffect particle = plugin.getCustomConfig().getParticle();
+				final Object particleData = plugin.getCustomConfig().getParticleData();
+
+				if (particleData instanceof ParticleColor) {
+					plugin.getCustomConfig().getParticle().display((ParticleColor) particleData, loc, player);
+				} else if (particleData instanceof ParticleData) {
+					particle.display((ParticleData) particleData, 0.0f, 0.0f, 0.0f, 0.0f, 1, loc, player);
+				} else {
+					particle.display(0.0f, 0.0f, 0.0f, 0.0f, 1, loc, player);
+				}
 			}
 		}
 	}

--- a/src/main/java/com/rojel/wesv/WorldEditHelper.java
+++ b/src/main/java/com/rojel/wesv/WorldEditHelper.java
@@ -60,7 +60,7 @@ public class WorldEditHelper extends BukkitRunnable {
 			try {
 				return selector.getRegion();
 			} catch (final IncompleteRegionException e) {
-				this.plugin.getServer().getLogger().info("Region still incomplete.");
+				this.plugin.getLogger().warning("Region still incomplete.");
 			}
 		}
 		return null;
@@ -71,7 +71,7 @@ public class WorldEditHelper extends BukkitRunnable {
 			return true;
 		}
 
-		if (r1 != null && r2 == null || r1 == null && r2 != null) {
+		if (r1 == null || r2 == null) {
 			return false;
 		}
 

--- a/src/main/java/com/rojel/wesv/WorldEditSelectionVisualizer.java
+++ b/src/main/java/com/rojel/wesv/WorldEditSelectionVisualizer.java
@@ -6,12 +6,12 @@ package com.rojel.wesv;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
-import com.sk89q.worldedit.WorldEdit;
 import org.bukkit.ChatColor;
 import org.bukkit.Location;
 import org.bukkit.command.Command;
@@ -19,7 +19,9 @@ import org.bukkit.command.CommandSender;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.plugin.java.JavaPlugin;
+import org.bukkit.util.StringUtil;
 
+import com.sk89q.worldedit.WorldEdit;
 import com.sk89q.worldedit.regions.Region;
 
 public class WorldEditSelectionVisualizer extends JavaPlugin {
@@ -58,7 +60,7 @@ public class WorldEditSelectionVisualizer extends JavaPlugin {
 		if (!command.getName().equalsIgnoreCase("wesv")) {
 			return false;
 		}
-		
+
 		if (args.length == 0 || !args[0].equalsIgnoreCase("reload") || !sender.hasPermission("wesv.reloadconfig")) {
 			if (sender instanceof Player) {
 				final Player player = (Player) sender;
@@ -82,6 +84,16 @@ public class WorldEditSelectionVisualizer extends JavaPlugin {
 			sender.sendMessage(this.config.getConfigReloaded());
 		}
 		return true;
+	}
+
+	@Override
+	public List<String> onTabComplete(final CommandSender sender, final Command command, final String alias,
+			final String[] args) {
+		if (args.length == 1 && sender.hasPermission("wesv.reloadconfig")) {
+			return StringUtil.copyPartialMatches(args[0], Collections.singletonList("reload"), new ArrayList<>());
+		}
+
+		return Collections.emptyList();
 	}
 
 	@SuppressWarnings("deprecation")

--- a/src/main/java/com/rojel/wesv/WorldEditSelectionVisualizer.java
+++ b/src/main/java/com/rojel/wesv/WorldEditSelectionVisualizer.java
@@ -90,7 +90,7 @@ public class WorldEditSelectionVisualizer extends JavaPlugin {
 	public List<String> onTabComplete(final CommandSender sender, final Command command, final String alias,
 			final String[] args) {
 		if (args.length == 1 && sender.hasPermission("wesv.reloadconfig")) {
-			return StringUtil.copyPartialMatches(args[0], Collections.singletonList("reload"), new ArrayList<>());
+			return StringUtil.copyPartialMatches(args[0], Collections.singletonList("reload"), new ArrayList<String>());
 		}
 
 		return Collections.emptyList();

--- a/src/resources/config.yml
+++ b/src/resources/config.yml
@@ -9,6 +9,7 @@ particleDistance: 32
 maxSize: 10000
 checkForAxe: false
 particleEffect: reddust
+particleData: "255,255,255"
 horizontalLinesForCuboid: true
 horizontalLinesForPolygon: true
 horizontalLinesForCylinder: true


### PR DESCRIPTION
* Add particles data (color or item)
* Fix error spam with some particles
* Correct some conventions
* Add tab-complete for command `/wesv`
* Support color codes in the config
* Use plugin logger instead of Bukkit logger in WorldEditHelper